### PR TITLE
Add pre-health check before calling a service.

### DIFF
--- a/syft_hub/services/chat.py
+++ b/syft_hub/services/chat.py
@@ -11,6 +11,7 @@ from syft_rpc.rpc import send, make_url
 from syft_rpc.protocol import SyftStatus
 
 from ..clients import AccountingClient, AuthClient
+from ..core.decorators import ensure_syftbox_running
 from ..core.types import ChatMessage, ServiceType
 from ..core.exceptions import RPCError, ValidationError, ServiceNotSupportedError, TransactionTokenCreationError
 from ..models.responses import ChatResponse
@@ -49,6 +50,7 @@ class ChatService:
         # Get user email from SyftBox auth (with guest fallback)
         self.from_email = self.auth_client.get_user_email()
 
+    @ensure_syftbox_running
     async def chat_with_params(self, params: Dict[str, Any], encrypt: bool = False) -> ChatResponse:
         """Send chat request with parameters.
         

--- a/syft_hub/services/search.py
+++ b/syft_hub/services/search.py
@@ -12,6 +12,7 @@ from syft_rpc.protocol import SyftStatus
 
 from ..clients import AccountingClient, AuthClient
 from ..core.types import ServiceType
+from ..core.decorators import ensure_syftbox_running
 from ..core.exceptions import RPCError, TransactionTokenCreationError, ValidationError, ServiceNotSupportedError
 from ..models.responses import SearchResponse
 from ..models.service_info import ServiceInfo
@@ -49,6 +50,7 @@ class SearchService:
         # Get user email from SyftBox auth (with guest fallback)
         self.from_email = self.auth_client.get_user_email()
 
+    @ensure_syftbox_running
     async def search_with_params(self, params: Dict[str, Any], encrypt: bool = False) -> SearchResponse:
         """Send search request with parameters.
         


### PR DESCRIPTION
## Description
This PR addresses a critical User Experience (UX) issue where a crashed or killed SyftBox daemon leads to the SDK hanging for a prolonged period, eventually failing with a non-specific timeout error, [issue #358](https://github.com/OpenMined/syft-internal-issues/issues/358).

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [ ] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
